### PR TITLE
Update use of CNL to reflect static_integer changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ message("-- INT128 = ${INT128}")
 message("-- STD = ${STD}")
 message("-- EXCEPTIONS = ${EXCEPTIONS}")
 
-set(CNL_GIT_TAG_DEFAULT b89764fb4845cc3a5e880e00d0c463520ee3ff92)
+set(CNL_GIT_TAG_DEFAULT 6cd6ad26786f767dd75ca7111a98ba83f0e39dff)
 set(CNL_GIT_TAG_ENV $ENV{CDSP_CNL_GIT_TAG})
 set(CNL_GIT_TAG "" CACHE BOOL "specify which revision of CNL to use")
 

--- a/include/cdsp/trig.h
+++ b/include/cdsp/trig.h
@@ -110,7 +110,7 @@ std::size_t trig<T>::get_twopi_index()
 template<class T>
 T trig<T>::sin_turn(T turn)
 {
-    auto mul = static_cast<cnl::elastic_number<TABLE_SIZE_IN_TWOS_POWER+2,0>>(TWOPI_INDEX);
+    auto mul = static_cast<cnl::elastic_scaled_integer<TABLE_SIZE_IN_TWOS_POWER+2,0>>(TWOPI_INDEX);
     auto index = static_cast<unsigned int>(cdsp::math::floor(turn * mul));
     T fra = turn * mul - index;
     T lo = sin_at(static_cast<std::size_t>(index));
@@ -123,7 +123,7 @@ T trig<T>::sin_turn(T turn)
 template<class T>
 T trig<T>::cos_turn(T turn)
 {
-    auto mul = static_cast<cnl::elastic_number<TABLE_SIZE_IN_TWOS_POWER+2,0>>(TWOPI_INDEX);
+    auto mul = static_cast<cnl::elastic_scaled_integer<TABLE_SIZE_IN_TWOS_POWER+2,0>>(TWOPI_INDEX);
     auto index = static_cast<unsigned int>(cdsp::math::floor(turn * mul));
     T fra = turn * mul - index;
     T lo = cos_at(static_cast<std::size_t>(index));
@@ -136,7 +136,7 @@ T trig<T>::cos_turn(T turn)
 template<class T>
 complex<T> trig<T>::exp_turn(T turn)
 {
-    auto mul = static_cast<cnl::elastic_number<TABLE_SIZE_IN_TWOS_POWER+2,0>>(TWOPI_INDEX);
+    auto mul = static_cast<cnl::elastic_scaled_integer<TABLE_SIZE_IN_TWOS_POWER+2,0>>(TWOPI_INDEX);
     auto index = static_cast<unsigned int>(cdsp::math::floor(turn * mul));
     T fra = turn * mul - index;
     complex<T> lo = operator[](index);

--- a/test/basic_math.cpp
+++ b/test/basic_math.cpp
@@ -78,10 +78,10 @@ TEST(basic_math, rounding_fixed_point)
 
 TEST(basic_math, rounding_elastic_number)
 {
-    
+
     using q4_4 = cdsp::rounding_elastic_number<8, -4>;
     using q4_1 = cdsp::rounding_elastic_number<4, -1>;
-    
+
     q4_4 a(0.4375);
     q4_1 b = a;
     EXPECT_EQ(a, 0.4375);
@@ -111,14 +111,14 @@ namespace test_rounding_should_stay_under_64_bits
 
 namespace test_convert_nearest_rounding_elastic_number
 {
-    static constexpr auto a = cnl::elastic_number<8, -4>{0.3125};
-    static constexpr auto b = cnl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -1>>(a);
-    static_assert(identical(cnl::elastic_number<4, -1>{0.5}, b),
-              "cnl::convert<nearest_rounding_tag, elastic_number, elastic_number>");
+    static constexpr auto a = cnl::elastic_scaled_integer<8, -4>{0.3125};
+    static constexpr auto b = cnl::convert<cnl::nearest_rounding_tag, cnl::elastic_scaled_integer<4, -1>>(a);
+    static_assert(identical(cnl::elastic_scaled_integer<4, -1>{0.5}, b),
+              "cnl::convert<nearest_rounding_tag, elastic_scaled_integer, elastic_scaled_integer>");
 
-    static constexpr auto c = cnl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -2>>(a);
-    static_assert(identical(cnl::elastic_number<4, -2>{0.25}, c),
-              "cnl::convert<nearest_rounding_tag, elastic_number, elastic_number>");
+    static constexpr auto c = cnl::convert<cnl::nearest_rounding_tag, cnl::elastic_scaled_integer<4, -2>>(a);
+    static_assert(identical(cnl::elastic_scaled_integer<4, -2>{0.25}, c),
+              "cnl::convert<nearest_rounding_tag, elastic_scaled_integer, elastic_scaled_integer>");
 }
 
 namespace test_convert_nearest_rounding_fixed_point


### PR DESCRIPTION
Per request from the WG21 numerics study group, `fixed_point` has been renamed `scaled_integer` and it's template parameters are more generalized. For now, at least, the original API is preserved as an alias but this may change soon. 

In the mean time, I took the opportunity to make minor naming changes which is what broke CDSP immediately. Some uses of 'number` were replaced with `scaled_integer` include `elastic_number` -> `elastic_scaled_integer`.

Sorry for the disruption.